### PR TITLE
use .py for determining if config should be a file, then raise exception...

### DIFF
--- a/ginkgo/runner.py
+++ b/ginkgo/runner.py
@@ -118,13 +118,17 @@ def load_class(class_path):
             class_path))
 
 def prepare_app(target):
-    if os.path.exists(target):
-        config = ginkgo.settings.load_file(target)
-        try:
-            service_factory = config['service']
-        except KeyError:
+    if target.endswith('.py'):
+        if os.path.exists(target):
+            config = ginkgo.settings.load_file(target)
+            try:
+                service_factory = config['service']
+            except KeyError:
+                raise RuntimeError(
+                    "Configuration does not specify a service factory")
+        else:
             raise RuntimeError(
-                "Configuration does not specify a service factory")
+                'Configuration file %s does not exist' % target)
     else:
         service_factory = target
     if isinstance(service_factory, str):


### PR DESCRIPTION
Currently, when you do:

```
$ ginkgo path/to/nonexistent/file.py.py 
```

you get the unlikely message:

```
Starting process with path/to/nonexistent/file.py.py...
usage: ginkgo [-v] [-h] [target]
ginkgo: error: Unable to load class path: path/to/nonexistent/file.py.py:Relative module names not supported
```

With this pull request, instead you'll get:

```
Starting process with ./deployment/api.conf.py...
usage: ginkgo [-v] [-h] [target]
ginkgo: error: Configuration file ./deployment/api.conf.py does not exist
```
