### PR TITLE
Fixes for SUID/SGID and SIGTERMs

### DIFF
--- a/ginkgo/core.py
+++ b/ginkgo/core.py
@@ -191,12 +191,6 @@ class BasicService(object):
             # already started, just move on
             pass
 
-        # This is done to recursively get services to wait on stopped.
-        # Services based on BasicService will not wait because they
-        # have no async manager and assume no event loop or threads.
-        for child in self._children:
-            child.serve_forever()
-
         self.state.wait("stopped")
 
     def __enter__(self):

--- a/ginkgo/runner.py
+++ b/ginkgo/runner.py
@@ -20,6 +20,8 @@ your application service and calls `serve_forever()` on it.
 """
 import argparse
 import logging
+import pwd
+import grp
 import os
 import os.path
 import runpy
@@ -278,17 +280,17 @@ class Process(ginkgo.core.Service, ginkgo.util.GlobalContext):
         gevent.signal(STOP_SIGNAL, self.stop)
 
     def post_start(self):
+        if self.group is not None:
+            grp_record = grp.getgrnam(self.group)
+            self.gid = grp_record.gr_gid
+            os.setgid(self.gid)
+
         if self.user is not None:
             pw_record = pwd.getpwnam(self.user)
             self.uid = pw_record.pw_uid
             self.gid = pw_record.pw_gid
-            os.setuid(self.uid)
             os.setgid(self.gid)
-
-        if self.group is not None:
-            grp_record = grp.getgrnam(self.group)
-            self.gid = grp_record.gr_gid
-            os.setgid(gid)
+            os.setuid(self.uid)
 
     def do_stop(self):
         logger.info("Stopping.")


### PR DESCRIPTION
Changed the order in which setuid and setgid is ran so that the process doesn't lose privilege to setgid after setuid completes

Fixes #71
Removed recursive child.serve_forever() from serve_forever(),
this was creating a bug where a child service's serve_forever() blocks, because the loop runs sequentially, the child's siblings' serve_forever() doesn't yet run.

When stop() is issued on the parent, the child's serve_forever() finishes, and the sibling's serve_forever() is called, which starts the sibling again, leading to an inconsistent state and the process never dies. This leads to the parent ginkgo service to not respond correctly to SIGTERMs

I believe the serve_forever() loop is redundant, because self.state.wait('stopped') will have already be waiting for all child services to stop. The parent will only transition to stopped after all child services have stopped.
