### PR TITLE
Fixes for runner.py

### DIFF
--- a/ginkgo/runner.py
+++ b/ginkgo/runner.py
@@ -19,9 +19,11 @@ your application service and calls `serve_forever()` on it.
 
 """
 import argparse
+import grp
 import logging
 import os
 import os.path
+import pwd
 import runpy
 import signal
 import sys
@@ -288,7 +290,7 @@ class Process(ginkgo.core.Service, ginkgo.util.GlobalContext):
         if self.group is not None:
             grp_record = grp.getgrnam(self.group)
             self.gid = grp_record.gr_gid
-            os.setgid(gid)
+            os.setgid(self.gid)
 
     def do_stop(self):
         logger.info("Stopping.")


### PR DESCRIPTION
`pwd` and `grp` weren't being imported and `gid` was an undefined variable that I assume was meant to be `self.gid`.

Note that there's still the issue of `Config` being undefined in that file but I wasn't sure how it was supposed to be used.
